### PR TITLE
Handle older nicks with no REGSERVER

### DIFF
--- a/mailer/daemon.py
+++ b/mailer/daemon.py
@@ -1,5 +1,6 @@
 import os
 import random
+import time
 import traceback
 from typing import Union
 
@@ -51,6 +52,11 @@ class Daemon:
         try:
             return data['nc']['REGSERVER']
         except KeyError:
+            # If the nick was registered more than an hour ago,
+            # assume it should use the default network
+            if data['time_registered'] < (time.time() - 3600):
+                return 'default'
+
             return None
 
     @property


### PR DESCRIPTION
If a nick hasn't been used or logged in to, it won't have REGSERVER set,
so if the nick is old enough, just use the default.