### PR TITLE
Add support for loading email templates from files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise AssertionError
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    if sys.version_info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+dist: xenial
+sudo: true
+python:
+- "3.6"
+- "3.7"
+
+branches:
+  only:
+  - master
+  # Allow tagged releases in the format v1.0
+  - /^v\d+\.\d+.*$/
+
+cache: pip
+
+install:
+- "pip install -Ur ./travis/requirements.txt"
+
+script:
+- "pytest"
+
+after_success:
+- codecov
+
+env:
+- PYTHONPATH=.

--- a/mailer/config.py
+++ b/mailer/config.py
@@ -6,7 +6,7 @@ from typing import Dict
 
 import yaml
 
-from mailer.email_template import EmailTemplate
+from .email_template import EmailTemplate
 from .network import Network
 from .reporter import ErrorReporter
 

--- a/mailer/email_template.py
+++ b/mailer/email_template.py
@@ -1,0 +1,36 @@
+import textwrap
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+__all__ = ('EmailTemplate',)
+
+SIMPLE_FMT = """\
+Subject: {subject}
+
+{body}
+"""
+
+
+class EmailTemplate:
+    def __init__(self, file: Path = None, config: Dict[str, Any] = None):
+        if config and file:
+            raise TypeError("Only one of 'body' or 'file' can be used")
+
+        if file:
+            with file.open(encoding='utf8') as f:
+                self.template = f.read()
+        else:
+            self.template = textwrap.dedent(SIMPLE_FMT).format_map(
+                config or {}
+            )
+
+    def generate(self, variables: Mapping[str, Any]) -> str:
+        return self.template.format_map(variables)
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]):
+        file = config.get('file')
+        if file:
+            return cls(file=Path(file).resolve())
+
+        return cls(config=config)

--- a/mailer/email_template.py
+++ b/mailer/email_template.py
@@ -14,7 +14,7 @@ Subject: {subject}
 class EmailTemplate:
     def __init__(self, file: Path = None, config: Dict[str, Any] = None):
         if config and file:
-            raise TypeError("Only one of 'body' or 'file' can be used")
+            raise TypeError("Only one of 'config' or 'file' can be used")
 
         if file:
             with file.open(encoding='utf8') as f:

--- a/mailer/network.py
+++ b/mailer/network.py
@@ -7,12 +7,11 @@ from typing import Dict, TYPE_CHECKING
 from mailer.email_template import EmailTemplate
 
 if TYPE_CHECKING:
-    from .daemon import Daemon
-    from .message import UserEmail
+    from . import daemon, message
 
 
 class Network:
-    def __init__(self, name, server_pattern, config, core: 'Daemon'):
+    def __init__(self, name, server_pattern, config, core: 'daemon.Daemon'):
         self.core = core
         self.name = name
         self.server_pattern = server_pattern
@@ -21,7 +20,7 @@ class Network:
         self.formats: Dict[str, EmailTemplate] = {}
 
     @classmethod
-    def from_config(cls, core: 'Daemon', net_config, config):
+    def from_config(cls, core: 'daemon.Daemon', net_config, config):
         net_obj = cls(net_config['name'], net_config['server'], net_config, core)
         net_obj.formats.update(config.default_formats)
         net_obj.formats.update(config.compile_templates(
@@ -32,12 +31,12 @@ class Network:
     def match_server(self, server):
         return fnmatch(server, self.server_pattern)
 
-    def format_message(self, message: 'UserEmail'):
+    def format_message(self, message: 'message.UserEmail'):
         fmt = self.formats[message.message_type]
         data = ChainMap({'network': self.name}, message.data)
         return fmt.generate(data)
 
-    def send_email(self, message: 'UserEmail'):
+    def send_email(self, message: 'message.UserEmail'):
         email: EmailMessage = message_from_string(
             self.format_message(message),
             policy=policy.SMTP,

--- a/mailer/network.py
+++ b/mailer/network.py
@@ -1,7 +1,10 @@
 from collections import ChainMap
+from email import message_from_string, policy
 from email.message import EmailMessage
 from fnmatch import fnmatch
-from typing import TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING
+
+from mailer.email_template import EmailTemplate
 
 if TYPE_CHECKING:
     from .daemon import Daemon
@@ -15,13 +18,15 @@ class Network:
         self.server_pattern = server_pattern
         self.config = config
         self.smtp_config = config['smtp']
-        self.formats = {}
+        self.formats: Dict[str, EmailTemplate] = {}
 
     @classmethod
     def from_config(cls, core: 'Daemon', net_config, config):
         net_obj = cls(net_config['name'], net_config['server'], net_config, core)
         net_obj.formats.update(config.default_formats)
-        net_obj.formats.update(net_config.get('formats', {}))
+        net_obj.formats.update(config.compile_templates(
+            net_config.get('formats', {})
+        ))
         return net_obj
 
     def match_server(self, server):
@@ -30,13 +35,14 @@ class Network:
     def format_message(self, message: 'UserEmail'):
         fmt = self.formats[message.message_type]
         data = ChainMap({'network': self.name}, message.data)
-        return fmt['subject'].format_map(data), fmt['message'].format_map(data)
+        return fmt.generate(data)
 
     def send_email(self, message: 'UserEmail'):
-        subject, body = self.format_message(message)
-        email = EmailMessage()
-        email.set_payload(body)
-        email['Subject'] = subject
+        email: EmailMessage = message_from_string(
+            self.format_message(message),
+            policy=policy.SMTP,
+        )
+        del email['To']
         email['To'] = message.user_email
 
         self.core.send_message(self.smtp_config, email)

--- a/mailer/network.py
+++ b/mailer/network.py
@@ -4,7 +4,7 @@ from email.message import EmailMessage
 from fnmatch import fnmatch
 from typing import Dict, TYPE_CHECKING
 
-from mailer.email_template import EmailTemplate
+from .email_template import EmailTemplate
 
 if TYPE_CHECKING:
     from . import daemon, message

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts =
+    --ignore=venv
+    --cov mailer --cov tests
+    --cov-report=xml
+    --doctest-modules
+testpaths = .

--- a/tests/test_email_template.py
+++ b/tests/test_email_template.py
@@ -1,0 +1,36 @@
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+
+def test_config_template():
+    config = {
+        'subject': "Test Subject",
+        'body': "Test Body",
+    }
+
+    from mailer.email_template import EmailTemplate
+    tmpl = EmailTemplate.from_config(config)
+
+    assert tmpl.generate({}) == "Subject: Test Subject\n\nTest Body\n"
+
+
+@pytest.fixture()
+def temp_file():
+    with NamedTemporaryFile() as f:
+        yield f
+
+
+def test_file_template(temp_file):
+    temp_file.write(
+        b'Subject: This is a test subject\r\n\r\nTest body\r\n{text}\r\n'
+    )
+    temp_file.flush()
+
+    config = {'file': temp_file.name}
+    from mailer.email_template import EmailTemplate
+    tmpl = EmailTemplate.from_config(config)
+
+    expected = 'Subject: This is a test subject\n\nTest body\nfoobar\n'
+
+    assert tmpl.generate({'text': 'foobar'}) == expected

--- a/travis/requirements.txt
+++ b/travis/requirements.txt
@@ -1,0 +1,6 @@
+pytest==4.5.0
+pytest-cov==2.7.1
+pytest-travis-fold==1.3.0
+codecov==2.0.15
+mock==3.0.5
+-r ../requirements.txt


### PR DESCRIPTION
This allow full customization of headers and email structure, while still allowing for the old format of just setting the subject and body in the config file